### PR TITLE
Document macOS setup and fix build script portability

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "java.project.sourcePaths": ["src"],
+  "java.project.referencedLibraries": [
+    "swt/**/*.jar"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ If you prefer running the compiled classes directly, use `"$JAVA_HOME/bin/java" 
 
 On first launch the application creates its data directory under `~/Library/Application Support/PKG Manager/`; creating it manually ahead of time avoids warning logs about missing files.
 
-If you want to provide feedback or to become a maintainer, either for linux/macos or windows, that would be much appreciated!
+---
+
+If you want to provide feedback or to become a maintainer, either for Linux, macOS, or Windows, that would be much appreciated!
 
 Regarding the current code: Basically I am using this project to learn Java. It is my first Java program (an upgrade so to speak from https://github.com/hippie68/ps4-pkg-compatibility-checker), so bear with me if, to put it mildly, large parts of the code are not idiomatic yet.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,36 @@ To compile the project into a .jar file, have a look at the file `build.sh`. If 
 
 Both scripts support SWT versions up to 4.35. SWT 4.36+ is currently not supported.
 
-The project is in dire need of supporters that use macOS. I don't have a Mac, so I don't know if the program in its current state works well and looks good on macOS. If you want to provide feedback or to become a maintainer, that would be much appreciated!
+## macOS Setup
+
+The helper scripts rely on GNU utilities that are not shipped with macOS by default. Before downloading SWT, install the required tools and run the downloader with the Homebrew versions:
+
+1. `brew install bash grep`
+2. `PATH="$(brew --prefix)/opt/grep/libexec/gnubin:$PATH" "$(brew --prefix)/bin/bash" download_swt.sh macos`
+
+The inline `PATH` update ensures the script can find GNU `grep`, and invoking the Homebrew `bash` provides the newer shell required by `download_swt.sh`.
+
+With the SWT files in place you can build the macOS jar locally:
+
+1. `chmod +x build.sh`
+2. `./build.sh macos`
+
+The script compiles against JDK 17, unpacks the SWT natives, and writes `build/macos/pkg_manager_macos.jar` for you to run or distribute.
+
+For Apple Silicon systems download the arm64 SWT bundle instead (`download_swt.sh macos-arm`) and build the matching jar with `./build.sh macos-arm`.
+
+### Running on macOS (Intel & Apple Silicon)
+
+SWT needs a Java 17 runtime that matches your architecture and must start on the first macOS thread. A typical Apple Silicon session looks like this:
+
+1. `export JAVA_HOME="$(/usr/libexec/java_home -v 17 --arch arm64)"`
+2. `"$JAVA_HOME/bin/java" -version` (confirm the output mentions `arm64`/`aarch64`).
+3. `"$JAVA_HOME/bin/java" -XstartOnFirstThread -jar build/macos-arm/pkg_manager_macos-arm.jar`
+
+If you prefer running the compiled classes directly, use `"$JAVA_HOME/bin/java" -XstartOnFirstThread -cp "build/macos-arm/classes:swt/4.37/macos-arm/swt.jar" GUI`.
+
+On first launch the application creates its data directory under `~/Library/Application Support/PKG Manager/`; creating it manually ahead of time avoids warning logs about missing files.
+
+If you want to provide feedback or to become a maintainer, either for linux/macos or windows, that would be much appreciated!
 
 Regarding the current code: Basically I am using this project to learn Java. It is my first Java program (an upgrade so to speak from https://github.com/hippie68/ps4-pkg-compatibility-checker), so bear with me if, to put it mildly, large parts of the code are not idiomatic yet.

--- a/build.sh
+++ b/build.sh
@@ -90,7 +90,7 @@ if [[ $# -lt 1 ]]; then
 fi
 
 [[ -d "$swt_dir" ]] || error "Required SWT directory does not exist: \"$swt_dir\"."
-[[ -v 2 ]] && swt_version=$2
+[[ $# -ge 2 ]] && swt_version=$2
 [[ $swt_version == "" ]] && swt_version=$(get_highest_version_dir)
 [[ $swt_version == "" ]] && error "Could not find an SWT version directory in SWT directory \"$swt_dir\"."
 hash unzip 2> /dev/null || error "Required program \"unzip\" not available."


### PR DESCRIPTION
Hi! I added a brief introduction explaining that these updates are meant to help macOS users set up the project and run SWT correctly.

- Added VS Code settings so that SWT JARs under `swt/**` are automatically included in the Java classpath.
- Expanded the README with macOS setup instructions: installing GNU tools, downloading the correct SWT build (Intel or Apple Silicon), building with `build.sh`, and running with a matching JDK and `-XstartOnFirstThread`.
- Updated `build.sh` to use a POSIX-compatible argument check (`[[ $# -ge 2 ]]`), allowing it to run correctly on the default macOS shell.

Tested on macOS 26.1, chip M4 arm-based